### PR TITLE
Ajout de la possibilité de visualiser une ligne de transport uniquement

### DIFF
--- a/core/class/geotrav.class.php
+++ b/core/class/geotrav.class.php
@@ -771,6 +771,12 @@ public function refreshStation($param = 'none') {
 	if ($param != 'none') {
 		$options = arg2array($param);
 	}
+	// code ligne exemple /lines/line:OST:E-1239
+	if ($this->getConfiguration('codeLigne') != '') {
+		$loc .= '/lines/line:'.getConfiguration('codeLigne');
+	}
+	
+	
 	//log::add('geotrav', 'debug', 'Station:Options ' . print_r($options));
 	$url = 'https://' . trim(config::byKey('keyNavitia', 'geotrav')) . '@api.navitia.io/v1/coverage/' . $loc;
 

--- a/core/class/geotrav.class.php
+++ b/core/class/geotrav.class.php
@@ -813,12 +813,14 @@ public function refreshStation($param = 'none') {
 			$this->checkAndUpdateCmd('station:1time', substr($jsondata['departures'][0]['stop_date_time']['departure_date_time'], 9, 4));
 			$this->checkAndUpdateCmd('station:1line', $jsondata['departures'][0]['display_informations']['code']);
 			$this->checkAndUpdateCmd('station:1stop', $jsondata['departures'][0]['stop_point']['name']);
+			$this->checkAndUpdateCmd('station:1lineCode', $jsondata['departures'][0]['route']['line']['id']);   			
 		}
 		if (isset($jsondata['departures'][1])) {
 			$this->checkAndUpdateCmd('station:2direction', $jsondata['departures'][1]['display_informations']['direction']);
 			$this->checkAndUpdateCmd('station:2time', substr($jsondata['departures'][1]['stop_date_time']['departure_date_time'], 9, 4));
 			$this->checkAndUpdateCmd('station:2line', $jsondata['departures'][1]['display_informations']['code']);
 			$this->checkAndUpdateCmd('station:2stop', $jsondata['departures'][1]['stop_point']['name']);
+			$this->checkAndUpdateCmd('station:2lineCode', $jsondata['departures'][1]['route']['line']['id']);    			
 		}
 		if ($this->getConfiguration('hideArrivee')) {
 			if (isset($jsondata['departures'][2])) {
@@ -826,12 +828,14 @@ public function refreshStation($param = 'none') {
 				$this->checkAndUpdateCmd('station:arrival1time', substr($jsondata['departures'][2]['stop_date_time']['departure_date_time'], 9, 4));
 				$this->checkAndUpdateCmd('station:arrival1line', $jsondata['departures'][2]['display_informations']['code']);
 				$this->checkAndUpdateCmd('station:arrival1stop', $jsondata['departures'][2]['stop_point']['name']);
+				$this->checkAndUpdateCmd('station:arrival1lineCode', $jsondata['departures'][2]['route']['line']['id']);       				
 			}
 			if (isset($jsondata['departures'][3])) {
 				$this->checkAndUpdateCmd('station:arrival2direction', $jsondata['departures'][3]['display_informations']['direction']);
 				$this->checkAndUpdateCmd('station:arrival2time', substr($jsondata['departures'][3]['stop_date_time']['departure_date_time'], 9, 4));
 				$this->checkAndUpdateCmd('station:arrival2line', $jsondata['departures'][3]['display_informations']['code']);
 				$this->checkAndUpdateCmd('station:arrival2stop', $jsondata['departures'][3]['stop_point']['name']);
+				$this->checkAndUpdateCmd('station:arrival2lineCode', $jsondata['departures'][3]['route']['line']['id']);   				
 			}
 		}
 	}
@@ -860,12 +864,14 @@ public function refreshStation($param = 'none') {
 			$this->checkAndUpdateCmd('station:arrival1time', substr($jsondata['arrivals'][0]['stop_date_time']['departure_date_time'], 9, 4));
 			$this->checkAndUpdateCmd('station:arrival1line', $jsondata['arrivals'][0]['display_informations']['code']);
 			$this->checkAndUpdateCmd('station:arrival1stop', $jsondata['arrivals'][0]['stop_point']['name']);
+            		$this->checkAndUpdateCmd('station:arrival1lineCode', $jsondata['arrivals'][0]['route']['line']['id']);           					
 		}
 		if (isset($jsondata['arrivals'][1])) {
 			$this->checkAndUpdateCmd('station:arrival2direction', $jsondata['arrivals'][1]['display_informations']['direction']);
 			$this->checkAndUpdateCmd('station:arrival2time', substr($jsondata['arrivals'][1]['stop_date_time']['departure_date_time'], 9, 4));
 			$this->checkAndUpdateCmd('station:arrival2line', $jsondata['arrivals'][1]['display_informations']['code']);
 			$this->checkAndUpdateCmd('station:arrival2stop', $jsondata['arrivals'][1]['stop_point']['name']);
+			$this->checkAndUpdateCmd('station:arrival2lineCode', $jsondata['arrivals'][1]['route']['line']['id']);      			
 		}
 		if ($this->getConfiguration('hideDepart')) {
 			if (isset($jsondata['arrivals'][2])) {
@@ -873,12 +879,14 @@ public function refreshStation($param = 'none') {
 				$this->checkAndUpdateCmd('station:1time', substr($jsondata['arrivals'][2]['stop_date_time']['departure_date_time'], 9, 4));
 				$this->checkAndUpdateCmd('station:1line', $jsondata['arrivals'][2]['display_informations']['code']);
 				$this->checkAndUpdateCmd('station:1stop', $jsondata['arrivals'][2]['stop_point']['name']);
+				$this->checkAndUpdateCmd('station:1lineCode', $jsondata['arrivals'][2]['route']['line']['id']);         				
 			}
 			if (isset($jsondata['arrivals'][3])) {
 				$this->checkAndUpdateCmd('station:2direction', $jsondata['arrivals'][3]['display_informations']['direction']);
 				$this->checkAndUpdateCmd('station:2time', substr($jsondata['arrivals'][3]['stop_date_time']['departure_date_time'], 9, 4));
 				$this->checkAndUpdateCmd('station:2line', $jsondata['arrivals'][3]['display_informations']['code']);
 				$this->checkAndUpdateCmd('station:2stop', $jsondata['arrivals'][3]['stop_point']['name']);
+				$this->checkAndUpdateCmd('station:2lineCode', $jsondata['arrivals'][3]['route']['line']['id']);				
 			}
 		}
 	}

--- a/core/class/geotrav.class.php
+++ b/core/class/geotrav.class.php
@@ -773,7 +773,7 @@ public function refreshStation($param = 'none') {
 	}
 	// code ligne exemple /lines/line:OST:E-1239
 	if ($this->getConfiguration('codeLigne') != '') {
-		$loc .= '/lines/line:'.getConfiguration('codeLigne');
+		$loc .= '/lines/line:'.$this->getConfiguration('codeLigne');
 	}
 	
 	

--- a/core/class/geotrav.class.php
+++ b/core/class/geotrav.class.php
@@ -773,7 +773,7 @@ public function refreshStation($param = 'none') {
 	}
 	// code ligne exemple /lines/line:OST:E-1239
 	if ($this->getConfiguration('codeLigne') != '') {
-		$loc .= '/lines/line:'.$this->getConfiguration('codeLigne');
+		$loc .= '/lines/'.$this->getConfiguration('codeLigne');
 	}
 	
 	

--- a/core/config/devices/station.json
+++ b/core/config/devices/station.json
@@ -40,6 +40,18 @@
             "logicalId": "station:1direction"
         },
         {
+            "name": "Départ 1 Code Ligne",
+            "type": "info",
+            "subtype": "string",
+            "display": {
+				"generic_type": "DONT"
+            },
+            "configuration": {
+				"type": "station"
+            },
+            "logicalId": "station:1lineCode"
+        },
+        {
             "name": "Départ 1 heure",
             "type": "info",
             "subtype": "numeric",
@@ -124,6 +136,18 @@
             "logicalId": "station:2stop"
         },
         {
+            "name": "Départ 2 Code Ligne",
+            "type": "info",
+            "subtype": "string",
+            "display": {
+				"generic_type": "DONT"
+            },
+            "configuration": {
+				"type": "station"
+            },
+            "logicalId": "station:2lineCode"
+        },        
+        {
             "name": "Arrivée 1 direction",
             "type": "info",
             "subtype": "string",
@@ -172,6 +196,18 @@
             "logicalId": "station:arrival1stop"
         },
         {
+            "name": "Arrivée 1 Code Ligne",
+            "type": "info",
+            "subtype": "string",
+            "display": {
+				"generic_type": "DONT"
+            },
+            "configuration": {
+				"type": "station"
+            },
+            "logicalId": "station:arrival1lineCode"
+        },      
+        {
             "name": "Arrivée 2 direction",
             "type": "info",
             "subtype": "string",
@@ -218,6 +254,18 @@
 				"type": "station"
             },
             "logicalId": "station:arrival2stop"
-        }
+        },
+        {
+            "name": "Arrivée 2 Code Ligne",
+            "type": "info",
+            "subtype": "string",
+            "display": {
+				"generic_type": "DONT"
+            },
+            "configuration": {
+				"type": "station"
+            },
+            "logicalId": "station:arrival2lineCode"
+        }        
     ]
 }

--- a/desktop/php/geotrav.php
+++ b/desktop/php/geotrav.php
@@ -373,9 +373,9 @@ $eqLogics = eqLogic::byType('geotrav');
 										</select>
 									</div>
 								</div>
-								<div class="form-group">
+								<div class="form-group" class="tooltipsered">
 									<label class="col-sm-2 control-label">{{Code ligne}}</label>
-									<div class="tooltipsered" class="col-sm-3">
+									<div  class="col-sm-3">
 										<input title="{{voir code ligne transport dans les commandes - exemple: line:OST:139}}" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="codeLigne" type="text" placeholder="{{Non obligatoire}}">
 				  				</div>
 								</div>								

--- a/desktop/php/geotrav.php
+++ b/desktop/php/geotrav.php
@@ -374,6 +374,12 @@ $eqLogics = eqLogic::byType('geotrav');
 									</div>
 								</div>
 								<div class="form-group">
+									<label class="col-sm-2 control-label">{{Code ligne}}</label>
+									<div class="col-sm-3">
+										<input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="codeLigne" type="text" placeholder="{{voir la doc}}">
+									</div>
+								</div>								
+								<div class="form-group">
 									<label class="col-sm-2 control-label">{{Options de transport}}</label>
 									<div class="col-sm-3">
 										<input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="stationOptions" type="text" placeholder="{{voir la doc}}">

--- a/desktop/php/geotrav.php
+++ b/desktop/php/geotrav.php
@@ -374,7 +374,7 @@ $eqLogics = eqLogic::byType('geotrav');
 									</div>
 								</div>
 								<div class="form-group" class="tooltipsered">
-									<label class="col-sm-2 control-label">{{Code ligne}}</label>
+									<label class="col-sm-2 control-label">{{Code ligne transport}}</label>
 									<div  class="col-sm-3">
 										<input title="{{voir code ligne transport dans les commandes - exemple: line:OST:139}}" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="codeLigne" type="text" placeholder="{{Non obligatoire}}">
 				  				</div>

--- a/desktop/php/geotrav.php
+++ b/desktop/php/geotrav.php
@@ -375,9 +375,9 @@ $eqLogics = eqLogic::byType('geotrav');
 								</div>
 								<div class="form-group">
 									<label class="col-sm-2 control-label">{{Code ligne}}</label>
-									<div class="col-sm-3">
-										<input class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="codeLigne" type="text" placeholder="{{voir la doc}}">
-									</div>
+									<div class="tooltipsered" class="col-sm-3">
+										<input title="{{voir code ligne transport dans les commandes - exemple: line:OST:139}}" class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="codeLigne" type="text" placeholder="{{Non obligatoire}}">
+				  				</div>
 								</div>								
 								<div class="form-group">
 									<label class="col-sm-2 control-label">{{Options de transport}}</label>


### PR DESCRIPTION
Ajout d'un paramètre pour afficher les heures d'arrivées pour une ligne de transport donnée. 
Ca peut être utile si la station est un point de passage pour beaucoup de lignes.
Pour cela il faut préciser le code de la ligne de transport. 
Ajout du code ligne dans les commandes infos pour retrouver le code ligne plus facilement.